### PR TITLE
Handle soft failure in password reset flow

### DIFF
--- a/src/modules/auth/handlers/PasswordRecoveryHandler.ts
+++ b/src/modules/auth/handlers/PasswordRecoveryHandler.ts
@@ -2,19 +2,23 @@ import User from '../model/User';
 import crypto from 'crypto';
 
 export class PasswordRecoveryHandler {
-  async requestReset(email: string): Promise<{ email: string; token: string }> {
+  async requestReset(
+    email: string
+  ): Promise<{ success: boolean; email?: string; token?: string }> {
     // Validate user exists
     const user = await User.findOne({ email });
     if (!user) {
-      throw new Error('User with this email does not exist.');
+      // Soft fail if the user does not exist
+      return { success: false };
     }
     // Generate token + expiry
     const token = await user.getResetPasswordToken();
     if (!token) {
       throw new Error('Failed to generate reset token.');
     }
-    // Save to user
+    // Return token and email
     return {
+      success: true,
       email,
       token,
     };

--- a/src/modules/auth/service/AuthService.ts
+++ b/src/modules/auth/service/AuthService.ts
@@ -48,13 +48,17 @@ export default class AuthService {
 
   public forgotPassword = async (req: Request, res: Response): Promise<Response> => {
     try {
-      const result = await this.passwordRecoveryHandler.requestReset(req.body.email);
+      const result = await this.passwordRecoveryHandler.requestReset(
+        req.body.email
+      );
 
-      // Emit event for password reset request
-      eventBus.publish('password.reset.requested', {
-        email: result.email,
-        token: result.token,
-      });
+      // Only emit event if a user was found and token generated
+      if (result.success) {
+        eventBus.publish('password.reset.requested', {
+          email: result.email!,
+          token: result.token!,
+        });
+      }
 
       return res.status(200).json({ message: 'Recovery email sent' });
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- update `PasswordRecoveryHandler.requestReset` to softly fail when no user found
- emit password reset event only when a user exists

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '../../models/ApiKeySchema')*

------
https://chatgpt.com/codex/tasks/task_e_6841a0a7442c83209ecc89aa9138d01d