### PR TITLE
Serve HTML homepage on root

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Free Agent Portal API</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f2f5;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    #container {
+      text-align: center;
+    }
+    h1 {
+      color: #333;
+    }
+  </style>
+</head>
+<body>
+  <div id="container">
+    <h1>Welcome to the Free Agent Portal API</h1>
+    <p id="status">Loading...</p>
+  </div>
+  <script>
+    document.getElementById('status').textContent =
+      'API is running - ' + new Date().toLocaleString();
+  </script>
+</body>
+</html>

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,7 +89,7 @@ function restartServer(callback: any) {
 app.use(errorHandler);
 
 app.get('/', (req: Request, res: Response) => {
-  res.send('API is running... Shepherds of Christ Ministries');
+  res.sendFile(path.join(__dirname, '../public/index.html'));
 });
 
 const numCPUs = os.cpus().length;


### PR DESCRIPTION
## Summary
- provide a basic web page for `/`
- send `index.html` from the new `public` folder

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686461245b288320ae7c4c94f4abb38a